### PR TITLE
allow specifying smtp user independent of smtp from

### DIFF
--- a/.env
+++ b/.env
@@ -27,3 +27,4 @@ EMAIL_PASSWORD=very_secure_password
 # PUID=911
 # PGID=911
 # USE_SECURE_RANDOM_ORG=1
+# EMAIL_USER=cooluser

--- a/root/etc/cont-init.d/40-msmtp-config.sh
+++ b/root/etc/cont-init.d/40-msmtp-config.sh
@@ -2,8 +2,11 @@
 . "/usr/local/bin/logger"
 program_name="msmtp-config"
 
+EMAIL_USER=${EMAIL_USER:-"${EMAIL_ADDRESS}"}
+
 echo "Configuring msmtp settings..." | info "[${program_name}] "
 sed -i "s/EMAIL_HOST/${EMAIL_HOST}/g" /etc/msmtprc
 sed -i "s/EMAIL_PORT/${EMAIL_PORT}/g" /etc/msmtprc
 sed -i "s/EMAIL_ADDRESS/${EMAIL_ADDRESS}/g" /etc/msmtprc
+sed -i "s/EMAIL_USER/${EMAIL_USER}/g" /etc/msmtprc
 sed -i "s/EMAIL_PASSWORD/${EMAIL_PASSWORD}/g" /etc/msmtprc

--- a/root/etc/msmtprc
+++ b/root/etc/msmtprc
@@ -7,7 +7,7 @@ tls on
 tls_starttls on
 
 auth login
-user EMAIL_ADDRESS
+user EMAIL_USER
 from EMAIL_ADDRESS
 password EMAIL_PASSWORD
 


### PR DESCRIPTION
for services such as sendgrid, the smtp `user` must always be `apikey`, so it's necessary to specify the `user` independently of the `from`. i've made these two new config options default to `EMAIL_ADDRESS` for backward compatibility purposes.