### PR TITLE
Upgrade workflow dependencies

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -51,13 +51,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         with:
           driver-opts: |
             env.BUILDKIT_STEP_LOG_MAX_SIZE=10000000
@@ -65,7 +65,7 @@ jobs:
           install: true
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         continue-on-error: true
         with:
           path: /tmp/.buildx-cache
@@ -107,7 +107,7 @@ jobs:
           docker save ci:${{ github.run_number }} | gzip > ci-${{ matrix.arch_friendly }}-${{ github.run_number }}.tar.gz
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ci-${{ matrix.arch_friendly }}-${{ github.run_number }}
           path: ci-${{ matrix.arch_friendly }}-${{ github.run_number }}.tar.gz
@@ -125,10 +125,10 @@ jobs:
           - arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Download container artifact
         uses: actions/download-artifact@v2
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download container artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v1
@@ -228,7 +228,7 @@ jobs:
           }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download container artifact
         uses: actions/download-artifact@v2
@@ -325,7 +325,7 @@ jobs:
           }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Docker login
         run: |

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: docker/setup-qemu-action@v2
 
       - name: Download container artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ci-${{ matrix.arch }}-${{ github.run_number }}
 
@@ -231,7 +231,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download container artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: ci-${{ matrix.arch }}-${{ github.run_number }}
 


### PR DESCRIPTION
Upgrade workflow dependencies because old dependencies running on Node 12 are being deprecated.
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/