### PR TITLE
Fixed "Could not load libcurl: libcurl-gnutls.so.4: cannot open share…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -214,6 +214,7 @@ RUN set -x \
         nginx \
         php-fpm \
         tzdata \
+        libcurl3-gnutls \
     && rm -rf /var/lib/apt/lists/*
 
 # Remove rsyslog as its unneeded and hangs the container on shutdown


### PR DESCRIPTION
…d object file: No such file or directory" when using Source Type cURL

When choosing source type cURL got error "Could not load libcurl: libcurl-gnutls.so.4: cannot open shared object file: No such file or directory"
Missing libcurl3-gnutls