### PR TITLE
Revert "Fixed "Could not load libcurl: libcurl-gnutls.so.4: cannot open share…"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -214,7 +214,6 @@ RUN set -x \
         nginx \
         php-fpm \
         tzdata \
-        libcurl3-gnutls \
     && rm -rf /var/lib/apt/lists/*
 
 # Remove rsyslog as its unneeded and hangs the container on shutdown


### PR DESCRIPTION
Reverts zoneminder-containers/zoneminder-base#44