### PR TITLE
Fixed "Could not load libcurl: libcurl-gnutls.so.4: cannot open share…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -214,6 +214,8 @@ RUN set -x \
         nginx \
         php-fpm \
         tzdata \
+        libcurl3-gnutls \
+    && ln -s /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.4 /usr/lib/libcurl-gnutls.so.4 \
     && rm -rf /var/lib/apt/lists/*
 
 # Remove rsyslog as its unneeded and hangs the container on shutdown


### PR DESCRIPTION
…d object file: No such file or directory" when using Source Type cURL

Added symlink

I think this helps