### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ There is also full support for multi-server setups with automation to link all s
 
 # How
 
-1. Install [Docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/)
+1. Install [Docker](https://docs.docker.com/get-docker/)
 2. Download docker-compose.yml or docker-compose-multi.yml depending on single/multi server setups.
 3. Download .env
 4. Place all these files in the same folder and configure .env and the yml files as you please.


### PR DESCRIPTION
Obsolete docker-compose no longer needs to be installed separately.